### PR TITLE
fixed rendering issue with treasure not being displayed

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,22 +1,10 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+    </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/src/main/java/evo/search/io/entities/Configuration.java
+++ b/src/main/java/evo/search/io/entities/Configuration.java
@@ -163,16 +163,15 @@ public class Configuration implements Cloneable, XmlEntity<Configuration> {
      * @return parsed treasure point
      * @see #parse(Document)
      */
-    private static DiscretePoint parseTreasure(final Element element) {
-        final Attribute amountPositions = element.attribute("amount");
+    private DiscretePoint parseTreasure(final Element element) {
         final Attribute positionAttribute = element.attribute("position");
         final Attribute distanceAttribute = element.attribute("distance");
-        if (positionAttribute == null || distanceAttribute == null || amountPositions == null) {
+        if (positionAttribute == null || distanceAttribute == null) {
             return null;
         }
         try {
             return new DiscretePoint(
-                    Integer.parseInt(amountPositions.getValue()),
+                    positions,
                     Integer.parseInt(positionAttribute.getValue()),
                     Double.parseDouble(distanceAttribute.getValue())
             );
@@ -207,7 +206,6 @@ public class Configuration implements Cloneable, XmlEntity<Configuration> {
      */
     private static Element writeTreasure(final DiscretePoint point) {
         return new DefaultElement("treasure")
-                .addAttribute("amount", String.valueOf(point.getPositions()))
                 .addAttribute("position", String.valueOf(point.getPosition()))
                 .addAttribute("distance", String.valueOf(point.getDistance()));
     }
@@ -276,9 +274,8 @@ public class Configuration implements Cloneable, XmlEntity<Configuration> {
             final ArrayList<DiscretePoint> treasures = new ArrayList<>();
             XmlService.forEach("treasure", treasuresElement, element -> {
                 final DiscretePoint discretePoint = parseTreasure(element);
-                if (discretePoint != null) {
+                if (discretePoint != null)
                     treasures.add(discretePoint);
-                }
             });
             setTreasures(treasures);
         }

--- a/src/main/java/evo/search/view/ConfigPanel.java
+++ b/src/main/java/evo/search/view/ConfigPanel.java
@@ -318,7 +318,7 @@ public class ConfigPanel extends JDialog {
             try {
                 final int position = Integer.parseInt(matcher.group(1));
                 final double distance = Double.parseDouble(matcher.group(2));
-                treasures.add(new DiscretePoint(0, position, distance));
+                treasures.add(new DiscretePoint(configuration.getPositions(), position, distance));
             } catch (final NumberFormatException ignored) {
             }
         }

--- a/src/main/java/evo/search/view/part/Canvas.java
+++ b/src/main/java/evo/search/view/part/Canvas.java
@@ -2,6 +2,7 @@ package evo.search.view.part;
 
 import evo.search.ga.DiscreteChromosome;
 import evo.search.ga.DiscreteGene;
+import evo.search.ga.DiscretePoint;
 import evo.search.view.render.Ray2D;
 import evo.search.view.render.StringShape;
 import evo.search.view.render.Style;
@@ -18,6 +19,7 @@ import java.awt.event.MouseMotionListener;
 import java.awt.geom.*;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -257,12 +259,7 @@ public class Canvas extends JPanel {
             }
         }
 
-        chromosome.getConfiguration().getTreasures().forEach(
-                treasure -> enqueue(
-                        treasure.toPoint2D(),
-                        Style.builder().shape(Style.Shape.CROSS).color(Color.RED).build()
-                )
-        );
+        renderTreasures(chromosome.getConfiguration().getTreasures());
     }
 
     /**
@@ -282,6 +279,18 @@ public class Canvas extends JPanel {
                             .build()
             );
         }
+    }
+
+    /**
+     * Render the treasure points as red crosses.
+     *
+     * @param treasures list of treasure points
+     */
+    public void renderTreasures(final List<DiscretePoint> treasures) {
+        treasures.forEach(treasure -> enqueue(
+                treasure.toPoint2D(),
+                Style.builder().color(Color.RED).shape(Style.Shape.CROSS).build()
+        ));
     }
 
     /**


### PR DESCRIPTION
Treasures had a `positions` property of 0 by default. Changed the parsing, the property is now linked to the configurations `positions` property.

Fixes #45 